### PR TITLE
Fix 6x-too-flexible TenNodeTetrahedron (double-applied 1/6 Jacobian factor in shp3d)

### DIFF
--- a/SRC/element/tetrahedron/TenNodeTetrahedron.cpp
+++ b/SRC/element/tetrahedron/TenNodeTetrahedron.cpp
@@ -2146,7 +2146,15 @@ TenNodeTetrahedron::shp3d( const double zeta[4], double &xsj, double shp[4][NumN
     double Jdet = (t1*(t5*t9-t6*t8) - t2*(t4*t9-t6*t7) + t3*(t4*t8-t5*t7))/6.0;
 
     // Saving the Jacobians Determinant
-    xsj = Jdet;
+    // BUGFIX: Jdet above already carries the tetrahedral 1/6 factor (it is the
+    // element VOLUME, not the raw 3x3 determinant). The Gauss weights wg[]
+    // sum to 1/6 (the natural-tet volume), so using xsj = Jdet applied the
+    // 1/6 factor TWICE -> every stiffness/mass/reaction came out 6x too soft
+    // (verified by a uniaxial patch test: reaction = E*eps*A / 6). The volume
+    // integrand must be the raw determinant D = 6*Jdet so that
+    // sum(wg)*xsj = (1/6)*D = V. The derivative shape functions below already
+    // use 1/(6*Jdet) = 1/D and are unaffected.
+    xsj = 6.0 * Jdet;
 
     // qx1 - qx10 (17.24)
     shp[0][0] = 1/(6.0*Jdet)*(dN1_dzeta1*a1  + dN1_dzeta2*a2  + dN1_dzeta3*a3  + dN1_dzeta4*a4);


### PR DESCRIPTION
## Summary

`TenNodeTetrahedron::shp3d` returns the Jacobian measure `xsj` used by every quadrature loop in the element (`dvol = wg * xsj`). The assembled determinant is divided by 6 —

```cpp
double Jdet = (t1*(t5*t9-t6*t8) - t2*(t4*t9-t6*t7) + t3*(t4*t8-t5*t7))/6.0;
xsj = Jdet;   // <-- bug
```

— which makes `Jdet` the **element volume**, not the raw 3×3 determinant. But the Gauss weights already carry the natural-tet volume: `wg[] = {1/24}` over 4 points sums to 1/6. So the 1/6 factor was applied **twice**, and every integrated quantity (stiffness, consistent and lumped mass, body loads, stress resultants) came out **6× too small**.

## Fix

```cpp
xsj = 6.0 * Jdet;
```

so that `Σ wg·xsj = (1/6)·(6·Jdet) = V` exactly. The shape-function derivatives are unaffected — they already normalize by `1/(6·Jdet)`.

## Verification

Uniaxial patch test — a single-element column with prescribed axial strain ε:

| | reaction |
|---|---|
| before | `E·ε·A / 6` |
| after | `E·ε·A` (exact) |

The total volume accumulated in `formInertiaTerms` (`volume += dvol`) now matches the geometric tet volume.

## Impact

Because **K and M scaled down together**, modal frequencies were essentially unchanged by the bug — which is why it could go unnoticed in eigen checks. The error shows up in absolute quantities: displacements under external loads 6× too large, reactions/element mass/self-weight 6× under-counted. Any model using `TenNodeTetrahedron` is affected, so this is worth flagging in release notes.

Authors: Nicolas Mora Bowen, Patricio Palacios, José A. Abell
