### PR TITLE
Portability and latent-crash fixes: FE_Element guard, PythonStream format string, DistributedSuperLU name collision

### DIFF
--- a/SRC/analysis/fe_ele/FE_Element.cpp
+++ b/SRC/analysis/fe_ele/FE_Element.cpp
@@ -170,25 +170,35 @@ FE_Element::FE_Element(int tag, int numDOF_Group, int ndof)
    myEle(0), theResidual(0), theTangent(0), theIntegrator(0)
 {
     // this is for a subtype, the subtype must set the myDOF_Groups ID array
-    numFEs++;
 
-    // if this is the first FE_Element we now
-    // create the arrays used to store pointers to class wide
-    // matrix and vector objects used to return tangent and residual
+    // If this is the first FE_Element, create the class-wide arrays that hold
+    // pointers to the shared tangent/residual matrix and vector objects.
+    //
+    // The increment of numFEs must happen AFTER this guard (the element-backed
+    // constructor above does exactly that). Incrementing first left this
+    // `numFEs == 0` test permanently false, so a model whose only FE_Elements
+    // are subtype adapters (no element-backed FE_Element ever built) never
+    // allocated theMatrices/theVectors -- a null dereference in ~FE_Element when
+    // the last FE_Element is destroyed. Any model that already owns an
+    // element-backed FE_Element is unaffected (numFEs is already > 0 by the time
+    // these subtypes are constructed).
     if (numFEs == 0) {
 	theMatrices = new Matrix *[MAX_NUM_DOF+1];
 	theVectors  = new Vector *[MAX_NUM_DOF+1];
-	
+
 	if (theMatrices == 0 || theVectors == 0) {
 	    opserr << "FE_Element::FE_Element(Element *) ";
-	    opserr << " ran out of memory";	    
+	    opserr << " ran out of memory";
 	}
 	for (int i=0; i<MAX_NUM_DOF; i++) {
 	    theMatrices[i] = 0;
 	    theVectors[i] = 0;
 	}
     }
-    
+
+    // increment number of FE_Elements by 1 (after the first-time allocation guard)
+    numFEs++;
+
     // as subtypes have no access to the tangent or residual we don't set them
     // this way we can detect if subclass does not provide all methods it should
 }

--- a/SRC/interpreter/PythonStream.h
+++ b/SRC/interpreter/PythonStream.h
@@ -66,7 +66,12 @@ template<class T>void PythonStream::err_out(T err)
   std::stringstream ss;
   ss << err;
   msg = ss.str();
-  PySys_FormatStderr(msg.c_str());
+  // Pass the already-formatted message as a %s argument, not as the format
+  // string itself. Any literal '%' in an opserr message (e.g. "50% of model
+  // mass") would otherwise be interpreted by PySys_FormatStderr as a printf
+  // conversion, so the message was silently dropped or garbled under openseespy
+  // (the Tcl StandardStream path is unaffected). Classic format-string bug.
+  PySys_FormatStderr("%s", msg.c_str());
 }
 
 

--- a/SRC/system_of_eqn/linearSOE/sparseGEN/DistributedSuperLU.cpp
+++ b/SRC/system_of_eqn/linearSOE/sparseGEN/DistributedSuperLU.cpp
@@ -66,7 +66,9 @@
 
 #endif
 
-SuperLUStat_t stat;
+// Renamed from `stat` to avoid a name collision with the POSIX stat() function
+// declared transitively via <sys/stat.h>/<io.h> on some toolchains (notably MSVC).
+SuperLUStat_t superlu_stat;
 SuperMatrix A;
 gridinfo_t grid;
 MPI_Comm comm_SuperLU;
@@ -188,7 +190,7 @@ DistributedSuperLU::solve(void)
     //
 
     pdgssvx_ABglobal(&options, &A, &ScalePermstruct, Xptr, ldb, nrhs, &grid,
-		     &LUstruct, berr, &stat, &info);
+		     &LUstruct, berr, &superlu_stat, &info);
 
     if (theSOE->factored == false) {
       options.Fact = FACTORED;      
@@ -254,7 +256,7 @@ DistributedSuperLU::setSize()
   //
   // Initialize the statistics variables.
   //
-  PStatInit(&stat);
+  PStatInit(&superlu_stat);
   
   //
   // Create compressed column matrix for A. 
@@ -294,7 +296,7 @@ DistributedSuperLU::setSize()
   //
   // Initialize the statistics variables. 
   //
-  PStatInit(&stat);
+  PStatInit(&superlu_stat);
 
   return 0;
 }


### PR DESCRIPTION
Three small, independent, non-behavioral fixes (one commit each, so any can be dropped). None changes results for a correctly-running model.

### 1. Dead first-element guard in `FE_Element` subtype constructor
`FE_Element(tag, numDOF_Group, ndof)` incremented the class-wide `numFEs` counter *before* the `if (numFEs == 0)` guard that lazily allocates the shared `theMatrices`/`theVectors` scratch arrays, so the guard was never taken. A model whose only `FE_Element`s are subtype adapters (no element-backed `FE_Element` ever constructed) then left those arrays unallocated → null dereference in `~FE_Element` when the last one is destroyed. Fix: increment after the guard, matching the element-backed constructor. Any model that owns at least one element-backed `FE_Element` is unaffected (`numFEs > 0` by the time subtypes are built).

### 2. Format-string bug in `PythonStream::err_out`
The already-formatted message was passed as the *format* argument of `PySys_FormatStderr`, so any literal `%` in an `opserr` message (e.g. `"50% of model mass"`) was consumed as a bogus printf conversion and the message dropped/garbled under openseespy. The Tcl stream path was unaffected. Fix: `PySys_FormatStderr("%s", msg.c_str())`.

### 3. `DistributedSuperLU` global `stat` collides with POSIX `stat()`
The file-scope `SuperLUStat_t stat` collides with the POSIX `stat()` declared transitively via `<sys/stat.h>`/`<io.h>` on some toolchains (notably MSVC), breaking the Windows build of the distributed SuperLU solver. Renamed to `superlu_stat` at all four use sites; no behavior change.

Authors: Nicolas Mora Bowen, Patricio Palacios, José A. Abell
