### PR TITLE
Serialize element-level rho in quad/triangle elements (fixes garbage mass on DB restore / MPI)

### DIFF
--- a/SRC/element/fourNodeQuad/EightNodeQuad.cpp
+++ b/SRC/element/fourNodeQuad/EightNodeQuad.cpp
@@ -201,7 +201,7 @@ EightNodeQuad::EightNodeQuad(int tag, int nd1, int nd2, int nd3, int nd4,
 EightNodeQuad::EightNodeQuad()
 :Element (0,ELE_TAG_EightNodeQuad),
   theMaterial(0), connectedExternalNodes(nnodes),
- Q(nnodes*2), applyLoad(0), pressureLoad(nnodes*2), thickness(0.0), pressure(0.0), Ki(0)
+ Q(nnodes*2), applyLoad(0), pressureLoad(nnodes*2), thickness(0.0), pressure(0.0), rho(0.0), Ki(0) // rho was left uninitialized in the blank (broker) constructor -> garbage element density on DB/parallel restore
 {
 	pts[0][0] = -0.7745966692414834;
 	pts[0][1] = -0.7745966692414834;
@@ -825,7 +825,7 @@ EightNodeQuad::sendSelf(int commitTag, Channel &theChannel)
 
   // Quad packs its data into a Vector and sends this to theChannel
   // along with its dbTag and the commitTag passed in the arguments
-  static Vector data(9);
+  static Vector data(10);
   data(0) = this->getTag();
   data(1) = thickness;
   data(2) = b[0];
@@ -836,6 +836,7 @@ EightNodeQuad::sendSelf(int commitTag, Channel &theChannel)
   data(6) = betaK;
   data(7) = betaK0;
   data(8) = betaKc;
+  data(9) = rho;  // serialize element-level rho: the mass matrix uses it when nonzero, but sendSelf/recvSelf never carried it, so a database restore / MPI send got garbage rho
 
   res += theChannel.sendVector(dataTag, commitTag, data);
   if (res < 0) {
@@ -894,7 +895,7 @@ EightNodeQuad::recvSelf(int commitTag, Channel &theChannel,
 
   // Quad creates a Vector, receives the Vector and then sets the
   // internal data with the data in the Vector
-  static Vector data(9);
+  static Vector data(10);
   res += theChannel.recvVector(dataTag, commitTag, data);
   if (res < 0) {
     opserr << "WARNING EightNodeQuad::recvSelf() - failed to receive Vector\n";
@@ -911,6 +912,7 @@ EightNodeQuad::recvSelf(int commitTag, Channel &theChannel,
   betaK = data(6);
   betaK0 = data(7);
   betaKc = data(8);
+  rho = data(9);  // restore element rho
 
   static ID idData(2*nip+nnodes);
   // Quad now receives the tags of its nine external nodes

--- a/SRC/element/fourNodeQuad/FourNodeQuad.cpp
+++ b/SRC/element/fourNodeQuad/FourNodeQuad.cpp
@@ -370,7 +370,7 @@ FourNodeQuad::FourNodeQuad(int tag, int nd1, int nd2, int nd3, int nd4,
 FourNodeQuad::FourNodeQuad()
 :Element (0,ELE_TAG_FourNodeQuad),
   theMaterial(0), connectedExternalNodes(4), 
- Q(8), pressureLoad(8), thickness(0.0), applyLoad(0), pressure(0.0), Ki(0)
+ Q(8), pressureLoad(8), thickness(0.0), applyLoad(0), pressure(0.0), rho(0.0), Ki(0) // rho was left uninitialized in the blank (broker) constructor -> garbage element density on DB/parallel restore
 {
   pts[0][0] = -0.577350269189626;
   pts[0][1] = -0.577350269189626;
@@ -989,7 +989,7 @@ FourNodeQuad::sendSelf(int commitTag, Channel &theChannel)
   
   // Quad packs its data into a Vector and sends this to theChannel
   // along with its dbTag and the commitTag passed in the arguments
-  static Vector data(11);
+  static Vector data(12);
   data(0) = this->getTag();
   data(1) = thickness;
   data(2) = b[0];
@@ -1014,6 +1014,8 @@ FourNodeQuad::sendSelf(int commitTag, Channel &theChannel)
 	  }
     data(10) = dbTag;
   }
+
+  data(11) = rho;  // serialize element-level rho: the mass matrix uses it when nonzero, but sendSelf/recvSelf never carried it, so a database restore / MPI send got garbage rho
 
   res += theChannel.sendVector(dataTag, commitTag, data);
   if (res < 0) {
@@ -1085,7 +1087,7 @@ FourNodeQuad::recvSelf(int commitTag, Channel &theChannel,
 
   // Quad creates a Vector, receives the Vector and then sets the 
   // internal data with the data in the Vector
-  static Vector data(11);
+  static Vector data(12);
   res += theChannel.recvVector(dataTag, commitTag, data);
   if (res < 0) {
     opserr << "WARNING FourNodeQuad::recvSelf() - failed to receive Vector\n";
@@ -1102,6 +1104,8 @@ FourNodeQuad::recvSelf(int commitTag, Channel &theChannel,
   betaK = data(6);
   betaK0 = data(7);
   betaKc = data(8);
+
+  rho = data(11);  // restore element rho
 
   static ID idData(12);
   // Quad now receives the tags of its four external nodes

--- a/SRC/element/fourNodeQuad/FourNodeQuad3d.cpp
+++ b/SRC/element/fourNodeQuad/FourNodeQuad3d.cpp
@@ -821,7 +821,7 @@ FourNodeQuad3d::sendSelf(int commitTag, Channel &theChannel)
   
   // Quad packs its data into a Vector and sends this to theChannel
   // along with its dbTag and the commitTag passed in the arguments
-  static Vector data(10);
+  static Vector data(11);
   data(0) = this->getTag();
   data(1) = thickness;
   data(3) = b[0];
@@ -832,7 +832,8 @@ FourNodeQuad3d::sendSelf(int commitTag, Channel &theChannel)
   data(7) = betaK;
   data(8) = betaK0;
   data(9) = betaKc;
-  
+  data(10) = rho;  // serialize element-level rho: the mass matrix uses it when nonzero, but sendSelf/recvSelf never carried it, so a database restore / MPI send got garbage rho
+
   res += theChannel.sendVector(dataTag, commitTag, data);
   if (res < 0) {
     opserr << "WARNING FourNodeQuad3d::sendSelf() - " << this->getTag() << " failed to send Vector\n";
@@ -892,7 +893,7 @@ FourNodeQuad3d::recvSelf(int commitTag, Channel &theChannel,
 
   // Quad creates a Vector, receives the Vector and then sets the 
   // internal data with the data in the Vector
-  static Vector data(10);
+  static Vector data(11);
   res += theChannel.recvVector(dataTag, commitTag, data);
   if (res < 0) {
     opserr << "WARNING FourNodeQuad3d::recvSelf() - failed to receive Vector\n";
@@ -909,6 +910,7 @@ FourNodeQuad3d::recvSelf(int commitTag, Channel &theChannel,
   betaK = data(7);
   betaK0 = data(8);
   betaKc = data(9);
+  rho = data(10);  // restore element rho
 
   static ID idData(12);
   // Quad now receives the tags of its four external nodes

--- a/SRC/element/fourNodeQuad/NineNodeQuad.cpp
+++ b/SRC/element/fourNodeQuad/NineNodeQuad.cpp
@@ -202,7 +202,7 @@ NineNodeQuad::NineNodeQuad(int tag, int nd1, int nd2, int nd3, int nd4,
 NineNodeQuad::NineNodeQuad()
 :Element (0,ELE_TAG_NineNodeQuad),
   theMaterial(0), connectedExternalNodes(nnodes),
- Q(2*nnodes), applyLoad(0), pressureLoad(2*nnodes), thickness(0.0), pressure(0.0), Ki(0)
+ Q(2*nnodes), applyLoad(0), pressureLoad(2*nnodes), thickness(0.0), pressure(0.0), rho(0.0), Ki(0) // rho was left uninitialized in the blank (broker) constructor -> garbage element density on DB/parallel restore
 {
 	pts[0][0] = -0.7745966692414834;
 	pts[0][1] = -0.7745966692414834;
@@ -839,7 +839,7 @@ NineNodeQuad::sendSelf(int commitTag, Channel &theChannel)
 
   // Quad packs its data into a Vector and sends this to theChannel
   // along with its dbTag and the commitTag passed in the arguments
-  static Vector data(9);
+  static Vector data(10);
   data(0) = this->getTag();
   data(1) = thickness;
   data(2) = b[0];
@@ -850,6 +850,7 @@ NineNodeQuad::sendSelf(int commitTag, Channel &theChannel)
   data(6) = betaK;
   data(7) = betaK0;
   data(8) = betaKc;
+  data(9) = rho;  // serialize element-level rho: the mass matrix uses it when nonzero, but sendSelf/recvSelf never carried it, so a database restore / MPI send got garbage rho
 
   res += theChannel.sendVector(dataTag, commitTag, data);
   if (res < 0) {
@@ -908,7 +909,7 @@ NineNodeQuad::recvSelf(int commitTag, Channel &theChannel,
 
   // Quad creates a Vector, receives the Vector and then sets the
   // internal data with the data in the Vector
-  static Vector data(9);
+  static Vector data(10);
   res += theChannel.recvVector(dataTag, commitTag, data);
   if (res < 0) {
     opserr << "WARNING NineNodeQuad::recvSelf() - failed to receive Vector\n";
@@ -925,6 +926,7 @@ NineNodeQuad::recvSelf(int commitTag, Channel &theChannel,
   betaK = data(6);
   betaK0 = data(7);
   betaKc = data(8);
+  rho = data(9);  // restore element rho
 
   static ID idData(2*nip+nnodes);
   // Quad now receives the tags of its nine external nodes

--- a/SRC/element/fourNodeQuad/SixNodeTri.cpp
+++ b/SRC/element/fourNodeQuad/SixNodeTri.cpp
@@ -187,7 +187,7 @@ SixNodeTri::SixNodeTri(int tag, int nd1, int nd2, int nd3, int nd4,
 SixNodeTri::SixNodeTri()
 :Element (0,ELE_TAG_SixNodeTri),
   theMaterial(0), connectedExternalNodes(nnodes),
- Q(2*nnodes), applyLoad(0), pressureLoad(2*nnodes), thickness(0.0), pressure(0.0), Ki(0)
+ Q(2*nnodes), applyLoad(0), pressureLoad(2*nnodes), thickness(0.0), pressure(0.0), rho(0.0), Ki(0) // rho was left uninitialized in the blank (broker) constructor -> garbage element density on DB/parallel restore
 {
 	pts[0][0] = 0.666666666666666667;
 	pts[0][1] = 0.166666666666666667;
@@ -771,7 +771,7 @@ SixNodeTri::sendSelf(int commitTag, Channel &theChannel)
 
   // Quad packs its data into a Vector and sends this to theChannel
   // along with its dbTag and the commitTag passed in the arguments
-  static Vector data(9);
+  static Vector data(10);
   data(0) = this->getTag();
   data(1) = thickness;
   data(2) = b[0];
@@ -782,6 +782,7 @@ SixNodeTri::sendSelf(int commitTag, Channel &theChannel)
   data(6) = betaK;
   data(7) = betaK0;
   data(8) = betaKc;
+  data(9) = rho;  // serialize element-level rho: the mass matrix uses it when nonzero, but sendSelf/recvSelf never carried it, so a database restore / MPI send got garbage rho
 
   res += theChannel.sendVector(dataTag, commitTag, data);
   if (res < 0) {
@@ -841,7 +842,7 @@ SixNodeTri::recvSelf(int commitTag, Channel &theChannel,
 
   // Quad creates a Vector, receives the Vector and then sets the
   // internal data with the data in the Vector
-  static Vector data(9);
+  static Vector data(10);
   res += theChannel.recvVector(dataTag, commitTag, data);
   if (res < 0) {
     opserr << "WARNING SixNodeTri::recvSelf() - failed to receive Vector\n";
@@ -858,6 +859,7 @@ SixNodeTri::recvSelf(int commitTag, Channel &theChannel,
   betaK = data(6);
   betaK0 = data(7);
   betaKc = data(8);
+  rho = data(9);  // restore element rho
 
   static ID idData(2*nip+nnodes);
   // Quad now receives the tags of its nine external nodes

--- a/SRC/element/triangle/Tri31.cpp
+++ b/SRC/element/triangle/Tri31.cpp
@@ -407,7 +407,7 @@ Tri31::Tri31(int tag, int nd1, int nd2, int nd3,
 
 Tri31::Tri31()
 :Element (0,ELE_TAG_Tri31),
-  theMaterial(0), connectedExternalNodes(3), Q(6), pressureLoad(6), thickness(0.0), pressure(0.0), Ki(0)
+  theMaterial(0), connectedExternalNodes(3), Q(6), pressureLoad(6), thickness(0.0), pressure(0.0), rho(0.0), Ki(0) // rho was left uninitialized in the blank (broker) constructor -> garbage element density on DB/parallel restore
 {
 	pts[0][0] = 0.333333333333333;
 	pts[0][1] = 0.333333333333333;
@@ -938,7 +938,7 @@ Tri31::sendSelf(int commitTag, Channel &theChannel)
   
     // Tri31 packs its data into a Vector and sends this to theChannel
     // along with its dbTag and the commitTag passed in the arguments
-    static Vector data(10);
+    static Vector data(11);
     data(0) = this->getTag();
     data(1) = thickness;
     data(3) = b[0];
@@ -949,7 +949,8 @@ Tri31::sendSelf(int commitTag, Channel &theChannel)
     data(7) = betaK;
     data(8) = betaK0;
     data(9) = betaKc;
-  
+    data(10) = rho;  // serialize element-level rho: the mass matrix uses it when nonzero, but sendSelf/recvSelf never carried it, so a database restore / MPI send got garbage rho
+
     res += theChannel.sendVector(dataTag, commitTag, data);
     if (res < 0) {
 		opserr << "WARNING Tri31::sendSelf() - " << this->getTag() << " failed to send Vector\n";
@@ -1006,7 +1007,7 @@ Tri31::recvSelf(int commitTag, Channel &theChannel, FEM_ObjectBroker &theBroker)
 
 	// Tri31 creates a Vector, receives the Vector and then sets the 
 	// internal data with the data in the Vector
-	static Vector data(10);
+	static Vector data(11);
 	res += theChannel.recvVector(dataTag, commitTag, data);
 	if (res < 0) {
 		opserr << "WARNING Tri31::recvSelf() - failed to receive Vector\n";
@@ -1023,6 +1024,7 @@ Tri31::recvSelf(int commitTag, Channel &theChannel, FEM_ObjectBroker &theBroker)
 	betaK  = data(7);
 	betaK0 = data(8);
 	betaKc = data(9);
+	rho    = data(10);  // restore element rho
 
 	static ID idData(2*numgp+numnodes+1);
 	// Tri31 now receives the tags of its four external nodes


### PR DESCRIPTION
`FourNodeQuad`, `FourNodeQuad3d`, `EightNodeQuad`, `NineNodeQuad`, `SixNodeTri` and `Tri31` pick their mass density as *"if element-level `rho` is nonzero use it, else fall back to the material density."* But `sendSelf`/`recvSelf` never packed `rho` into the data `Vector`, and every blank (broker) constructor **except** `FourNodeQuad3d` left `rho` uninitialized.

So after a `database` restore or an OpenSeesMP send, `rho` held garbage heap data. A nonzero garbage value then hijacked the mass matrix → non-deterministic, often **indefinite** M (negative generalized eigenvalues) and diverging transient restarts.

### Fix (additive)
- Append `rho` to each element's send/recv data `Vector` (+1 slot).
- Initialize `rho(0.0)` in the blank constructors that lacked it.

Committed nodal displacements round-trip fine, so a plain `nodeDisp` restore test does not expose this — it only shows once the restored model integrates in time.

### Wire-format note
The send/recv `Vector` grows by one slot for these element types, so a model saved/sent by this build is not binary-compatible with a **stock-built** peer for those elements. This only matters for mixed-build database-restore / MPI runs.

Authors: Nicolas Mora Bowen, Patricio Palacios, José A. Abell
