### PR TITLE
Clear EQ_Constraints in Domain::clearAll() (fixes leak + stale non-empty domain after wipe)

### DIFF
--- a/SRC/domain/domain/Domain.cpp
+++ b/SRC/domain/domain/Domain.cpp
@@ -1051,6 +1051,7 @@ Domain::clearAll(void) {
   theSPs->clearAll();
   thePCs->clearAll();
   theMPs->clearAll();
+  theEQs->clearAll();   // was omitted: EQ_Constraints survived clearAll()/wipe() (leak + stale non-empty domain)
   theLoadPatterns->clearAll();
   theParameters->clearAll();
   numParameters = 0;


### PR DESCRIPTION
`Domain::clearAll()` (called by `wipe()`) empties every tagged-object container it owns — elements, nodes, SP/PC/MP constraints, load patterns, parameters — **except `theEQs`**. So `EQ_Constraint` objects survived a wipe: never freed (leak), and since `theEQs->getNumComponents()` stayed nonzero the domain still reported itself non-empty afterward.

Fix: add the missing `theEQs->clearAll()` next to the other constraint containers. No effect on a model that holds no `EQ_Constraint`s.

Authors: Nicolas Mora Bowen, Patricio Palacios, José A. Abell
